### PR TITLE
DEV-ISSUE-02: enrol_coursepilot Get template categories

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -47,19 +47,23 @@ class external extends external_api {
      * @param string $name Optional. The name of the course category to filter by.
      * @return array The settings for the specified course categories.
      */
-    protected static function get_settings_course_categories($name = '') {
+    public static function get_settings_course_categories($name = '') {
         global $DB;
 
         if (empty($name)) {
             return [];
         }
 
+        // Get the settings for the specified course categories.
+        $enabled = get_config('enrol_coursepilot', 'enable');
         $config = get_config('enrol_coursepilot', $name);
 
-        if (empty($config) || !is_string($config)) {
+        // Validate that the settings are not empty.
+        if (empty($config) || empty($enabled) || !is_string($config)) {
             return [];
         }
 
+        // Get the course categories.
         $categories = [];
         foreach (explode(',', $config) as $category) {
             $category = trim($category);

--- a/classes/external.php
+++ b/classes/external.php
@@ -1,0 +1,112 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * External API.
+ *
+ * @package     enrol_coursepilot
+ * @copyright   2024 Diego Monroy <dfelipe.monroyc@gmail.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace enrol_coursepilot;
+
+defined('MOODLE_INTERNAL') || die;
+
+global $CFG;
+require_once($CFG->libdir . "/externallib.php");
+require_once($CFG->dirroot . "/course/externallib.php");
+
+use external_api;
+use external_function_parameters;
+use external_multiple_structure;
+use external_single_structure;
+use external_value;
+
+/**
+ * Represents an external class that extends the external_api class.
+ */
+class external extends external_api {
+
+    /**
+     * Retrieves the settings for course categories.
+     *
+     * @param string $name Optional. The name of the course category to filter by.
+     * @return array The settings for the specified course categories.
+     */
+    protected static function get_settings_course_categories($name = '') {
+        global $DB;
+
+        if (empty($name)) {
+            return [];
+        }
+
+        $config = get_config('enrol_coursepilot', $name);
+
+        if (empty($config) || !is_string($config)) {
+            return [];
+        }
+
+        $categories = [];
+        foreach (explode(',', $config) as $category) {
+            $category = trim($category);
+            $category = $DB->get_record('course_categories', ['id' => $category], 'id, name');
+
+            if (!empty($category)) {
+                $categories[$category->id] = [
+                    'id' => $category->id,
+                    'name' => $category->name,
+                ];
+            }
+        }
+
+        return $categories;
+    }
+
+    /**
+     * Returns a list of coruse categories ids.
+     * @return array
+     */
+    public static function get_template_categories() {
+        return self::get_settings_course_categories('templatecategories');
+    }
+
+    /**
+     * Returns description of method parameters.
+     * @return external_function_parameters
+     */
+    public static function get_template_categories_parameters() {
+        return new external_function_parameters(
+            []
+        );
+    }
+
+    /**
+     * Returns description of method result value.
+     * @return external_multiple_structure
+     */
+    public static function get_template_categories_returns(): external_multiple_structure {
+        return new external_multiple_structure(
+            new external_single_structure(
+                [
+                    'id' => new external_value(PARAM_INT, 'The category id.'),
+                    'name' => new external_value(PARAM_TEXT, 'The category name.'),
+                ]
+            )
+        );
+    }
+
+}

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Web services and external functions for enrol_coursepilot plugin are defined here.
+ *
+ * @package     enrol_coursepilot
+ * @copyright   2024 Diego Monroy <dfelipe.monroyc@gmail.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+// We define the web service functions to install as pre-build functions. A pre-build function is not editable by administrator.
+$functions = [
+    'enrol_coursepilot_get_template_categories' => [
+        'classname' => 'enrol_coursepilot\external',
+        'methodname' => 'get_template_categories',
+        'classpath' => 'enrol/coursepilot/classes/external.php',
+        'description' => 'Get configured template categories.',
+        'type' => 'read',
+        'ajax' => true,
+    ],
+];
+
+// We define the services to install as pre-build services. A pre-build service is not editable by administrator.
+$services = [
+    'Enrol Course Pilot Configuration Service' => [
+        'functions' => [
+            'enrol_coursepilot_get_template_categories',
+        ],
+        'restrictedusers' => 0,
+        'enabled' => 1,
+    ],
+];

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace enrol_coursepilot;
+namespace enrol_coursepilot\external;
 
 use advanced_testcase;
 
@@ -100,6 +100,38 @@ class external_test extends advanced_testcase {
     }
 
     /**
+     * Retrieves a list of random categories.
+     *
+     * This method fetches a set of categories randomly selected from the available categories.
+     *
+     * @return array An array of randomly selected categories.
+     */
+    protected function get_random_categories() {
+        // If there are no categories, return an empty array.
+        if (empty($this->categories)) {
+            return [];
+        }
+
+        // If the number of categories is less than the random categories, return all categories.
+        if (count($this->categories) <= $this->randomcategories) {
+            return $this->categories;
+        }
+
+        // We choose random categories to set as template categories.
+        $randomkeys = array_rand($this->categories, $this->randomcategories);
+
+        // If only one key is returned, wrap it in an array for consistency.
+        if (!is_array($randomkeys)) {
+            $randomkeys = [$randomkeys];
+        }
+
+        // Retrieve the random categories using the selected keys and return them.
+        return array_map(function($key) {
+            return $this->categories[$key];
+        }, $randomkeys);
+    }
+
+    /**
      * Test method for retrieving settings of course categories via the external API.
      *
      * This method is designed to test the functionality of getting
@@ -108,8 +140,10 @@ class external_test extends advanced_testcase {
      * @return void
      */
     public function test_get_template_categories() {
-        // We choose random categories to set as template categories.
-        $categories = array_slice($this->categories, 0, $this->randomcategories);
+        // We get random categories to set as template categories.
+        $categories = $this->get_random_categories();
+
+        // Convert the randomly chosen categories to a comma-separated string of IDs.
         $strcategories = implode(',', array_column($categories, 'id'));
 
         // Set the configuration settings for the coursepilot enrolment plugin, disabled first.
@@ -120,7 +154,7 @@ class external_test extends advanced_testcase {
         $this->set_enrol_coursepilot_settings($data);
 
         // Retrieve the template categories.
-        $templatecategories = external::get_template_categories();
+        $templatecategories = \enrol_coursepilot\external::get_template_categories();
 
         // Assert that the template categories retrieved are empty.
         $this->assertEmpty($templatecategories);
@@ -130,7 +164,7 @@ class external_test extends advanced_testcase {
         $this->set_enrol_coursepilot_settings($data);
 
         // Retrieve the template categories.
-        $templatecategories = external::get_template_categories();
+        $templatecategories = \enrol_coursepilot\external::get_template_categories();
 
         // Assert that the template categories are retrieved successfully.
         $this->assertCount($this->randomcategories, $templatecategories);

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -1,0 +1,136 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * External API Test cases for enrol_coursepilot
+ *
+ * @package   enrol_coursepilot
+ * @copyright 2024 Diego Monroy <dfelipe.monroyc@gmail.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace enrol_coursepilot;
+
+use advanced_testcase;
+use core_course_category;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class external_test
+ *
+ * This class extends advanced_testcase and is used for testing purposes
+ * within the Moodle enrolment coursepilot plugin.
+ *
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @package    enrol_coursepilot
+ * @category   test
+ * @copyright  2024 Diego Monroy <dfelipe.monroyc@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class external_test extends advanced_testcase {
+
+    protected array $categories = [];
+
+    /**
+     * Set up method for initializing the test environment.
+     *
+     * This method is called before each test is executed.
+     *
+     * @return void
+     */
+    public function setUp(): void {
+        // Set up the test environment.
+        $this->setAdminUser();
+        $this->resetAfterTest();
+
+        // Initialize the database generator.
+        $dg = $this->getDataGenerator();
+
+        // Create 5 course categories.
+        for ($i = 1; $i <= 5; $i++) {
+            $options = [
+                'idnumber' => 'category' . $i,
+                'name' => 'Category ' . $i,
+                'description' => 'Category ' . $i . ' description',
+            ];
+            $this->categories[] = $dg->create_category($options);
+        }
+
+        // Create 1 Course in each category.
+        foreach ($this->categories as $category) {
+            $options = [
+                'category' => $category->id,
+            ];
+            $dg->create_course($options);
+        }
+    }
+
+    /**
+     * Set the configuration settings for the coursepilot enrolment plugin.
+     *
+     * @param array $settings An associative array of settings to configure the external test.
+     */
+    protected function set_enrol_coursepilot_settings($settings = []) {
+        // Set the given configuration settings.
+        foreach ($settings as $name => $value) {
+            set_config($name, $value, 'enrol_coursepilot');
+        }
+    }
+
+    /**
+     * Test method for retrieving settings of course categories via the external API.
+     *
+     * This method is designed to test the functionality of getting
+     * settings for course categories within the Moodle environment.
+     *
+     * @return void
+     */
+    public function test_get_template_categories() {
+        // Set the configuration settings for the coursepilot enrolment plugin, disabled first.
+        $strcategories = implode(',', array_column($this->categories, 'id'));
+        $data = [
+            'enable' => 0,
+            'templatecategories' => $strcategories
+        ];
+        $this->set_enrol_coursepilot_settings($data);
+
+        // Retrieve the template categories.
+        $templatecategories = external::get_template_categories();
+
+        // Assert that the template categories retrieved are empty.
+        $this->assertEmpty($templatecategories);
+
+        // Now we set the configuration settings for the coursepilot enrolment plugin, enabled.
+        $data['enable'] = 1;
+        $this->set_enrol_coursepilot_settings($data);
+
+        // Retrieve the template categories.
+        $templatecategories = external::get_template_categories();
+
+        // Assert that the template categories are retrieved successfully.
+        $this->assertCount(5, $templatecategories);
+
+        // Assert that the template categories are correct.
+        foreach ($this->categories as $category) {
+            $this->assertArrayHasKey($category->id, $templatecategories);
+            $this->assertEquals($category->name, $templatecategories[$category->id]['name']);
+        }
+    }
+
+}

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -32,9 +32,7 @@ use advanced_testcase;
  * This class extends advanced_testcase and is used for testing purposes
  * within the Moodle enrolment coursepilot plugin.
  *
- *
  * @runTestsInSeparateProcesses
- *
  * @package    enrol_coursepilot
  * @category   test
  * @copyright  2024 Diego Monroy <dfelipe.monroyc@gmail.com>
@@ -44,7 +42,7 @@ class external_test extends advanced_testcase {
 
     /**
      * @var array $categories An array to store categories.
-     * 
+     *
      * This protected property holds an array of categories. It is initialized as an empty array.
      */
     protected array $categories = [];
@@ -69,7 +67,7 @@ class external_test extends advanced_testcase {
         // Initialize the database generator.
         $dg = $this->getDataGenerator();
 
-        // Create 5 course categories.
+        // Create 10 course categories.
         for ($i = 1; $i <= 10; $i++) {
             $options = [
                 'idnumber' => 'category' . $i,

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -32,11 +32,12 @@ use advanced_testcase;
  * This class extends advanced_testcase and is used for testing purposes
  * within the Moodle enrolment coursepilot plugin.
  *
- * @runTestsInSeparateProcesses
  * @package    enrol_coursepilot
  * @category   test
  * @copyright  2024 Diego Monroy <dfelipe.monroyc@gmail.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @runTestsInSeparateProcesses
  */
 class external_test extends advanced_testcase {
 

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -25,9 +25,6 @@
 namespace enrol_coursepilot;
 
 use advanced_testcase;
-use core_course_category;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class external_test
@@ -45,7 +42,17 @@ defined('MOODLE_INTERNAL') || die();
  */
 class external_test extends advanced_testcase {
 
+    /**
+     * @var array $categories An array to store categories.
+     * 
+     * This protected property holds an array of categories. It is initialized as an empty array.
+     */
     protected array $categories = [];
+
+    /**
+     * @var int $randomcategories Number of random categories.
+     */
+    protected int $randomcategories = 5;
 
     /**
      * Set up method for initializing the test environment.
@@ -63,7 +70,7 @@ class external_test extends advanced_testcase {
         $dg = $this->getDataGenerator();
 
         // Create 5 course categories.
-        for ($i = 1; $i <= 5; $i++) {
+        for ($i = 1; $i <= 10; $i++) {
             $options = [
                 'idnumber' => 'category' . $i,
                 'name' => 'Category ' . $i,
@@ -102,8 +109,11 @@ class external_test extends advanced_testcase {
      * @return void
      */
     public function test_get_template_categories() {
+        // We choose random categories to set as template categories.
+        $categories = array_slice($this->categories, 0, $this->randomcategories);
+        $strcategories = implode(',', array_column($categories, 'id'));
+
         // Set the configuration settings for the coursepilot enrolment plugin, disabled first.
-        $strcategories = implode(',', array_column($this->categories, 'id'));
         $data = [
             'enable' => 0,
             'templatecategories' => $strcategories
@@ -124,12 +134,11 @@ class external_test extends advanced_testcase {
         $templatecategories = external::get_template_categories();
 
         // Assert that the template categories are retrieved successfully.
-        $this->assertCount(5, $templatecategories);
+        $this->assertCount($this->randomcategories, $templatecategories);
 
         // Assert that the template categories are correct.
-        foreach ($this->categories as $category) {
-            $this->assertArrayHasKey($category->id, $templatecategories);
-            $this->assertEquals($category->name, $templatecategories[$category->id]['name']);
+        foreach ($templatecategories as $category) {
+            $this->assertContains($category['id'], array_column($categories, 'id'));
         }
     }
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_coursepilot';
 $plugin->release   = '1.0.0';
-$plugin->version   = 2024101500;
+$plugin->version   = 2024102400;
 $plugin->requires  = 2024042204;  // Requires Moodle 4.4.4.
 $plugin->supported = [404, 405];  // Supports Moodle 4.4 and 4.5.
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_coursepilot';
 $plugin->release   = '1.0.0';
-$plugin->version   = 2024101400;
+$plugin->version   = 2024101500;
 $plugin->requires  = 2024042204;  // Requires Moodle 4.4.4.
 $plugin->supported = [404, 405];  // Supports Moodle 4.4 and 4.5.
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_coursepilot';
 $plugin->release   = '1.0.0';
-$plugin->version   = 2024102400;
+$plugin->version   = 2024102600;
 $plugin->requires  = 2024042204;  // Requires Moodle 4.4.4.
 $plugin->supported = [404, 405];  // Supports Moodle 4.4 and 4.5.
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
DEV-ISSUE-02: enrol_coursepilot Get template categories

**Story**
As a web service consumer I can get the template category ids using a web service function

https://github.com/sofhouse/moodle-enrol_coursepilot/issues/2