### PR TITLE
DEV-ISSUE-03: enrol_coursepilot Get formations categories

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -109,4 +109,37 @@ class external extends external_api {
         );
     }
 
+    /**
+     * Returns a list of coruse categories ids.
+     * @return array
+     */
+    public static function get_formations_categories() {
+        return self::get_settings_course_categories('formationcategories');
+    }
+
+    /**
+     * Returns description of method parameters.
+     * @return external_function_parameters
+     */
+    public static function get_formations_categories_parameters() {
+        return new external_function_parameters(
+            []
+        );
+    }
+
+    /**
+     * Returns description of method result value.
+     * @return external_multiple_structure
+     */
+    public static function get_formations_categories_returns(): external_multiple_structure {
+        return new external_multiple_structure(
+            new external_single_structure(
+                [
+                    'id' => new external_value(PARAM_INT, 'The category id.'),
+                    'name' => new external_value(PARAM_TEXT, 'The category name.'),
+                ]
+            )
+        );
+    }
+
 }

--- a/classes/external.php
+++ b/classes/external.php
@@ -50,16 +50,21 @@ class external extends external_api {
     protected static function get_settings_course_categories($name = '') {
         global $DB;
 
+        // Validate that the name is not empty.
         if (empty($name)) {
             return [];
         }
 
+        // Get the settings for the specified course categories.
+        $enabled = get_config('enrol_coursepilot', 'enable');
         $config = get_config('enrol_coursepilot', $name);
 
-        if (empty($config) || !is_string($config)) {
+        // Validate that the settings are not empty.
+        if (empty($config) || empty($enabled) || !is_string($config)) {
             return [];
         }
 
+        // Get the course categories.
         $categories = [];
         foreach (explode(',', $config) as $category) {
             $category = trim($category);

--- a/db/services.php
+++ b/db/services.php
@@ -34,6 +34,14 @@ $functions = [
         'type' => 'read',
         'ajax' => true,
     ],
+    'enrol_coursepilot_get_formations_categories' => [
+        'classname' => 'enrol_coursepilot\external',
+        'methodname' => 'get_formations_categories',
+        'classpath' => 'enrol/coursepilot/classes/external.php',
+        'description' => 'Get configured formations categories.',
+        'type' => 'read',
+        'ajax' => true,
+    ],
 ];
 
 // We define the services to install as pre-build services. A pre-build service is not editable by administrator.
@@ -41,6 +49,7 @@ $services = [
     'Enrol Course Pilot Configuration Service' => [
         'functions' => [
             'enrol_coursepilot_get_template_categories',
+            'enrol_coursepilot_get_formations_categories',
         ],
         'restrictedusers' => 0,
         'enabled' => 1,

--- a/settings.php
+++ b/settings.php
@@ -29,9 +29,11 @@ if ($hassiteconfig) {
     $pluginname = 'enrol_coursepilot';
     $categories = core_course_category::make_categories_list('moodle/category:manage');
 
+    // Add a new category to the enrolments category.
     $ADMIN->add('enrolments', new admin_category('enrolcoursepilotfolder', new lang_string('pluginname', $pluginname),
         $this->is_enabled() === false));
 
+    // Add a new section to the enrolments category.
     $visiblename = get_string('setting_configpage', $pluginname);
     $settings = new admin_settingpage($section, $visiblename, 'moodle/site:config', $this->is_enabled() === false);
 

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -184,8 +184,10 @@ class external_test extends advanced_testcase {
      * @return void
      */
     public function test_get_formations_categories() {
-        // We choose random categories to set as template categories.
-        $categories = array_slice($this->categories, 0, $this->randomcategories);
+        // We get random categories to set as formation categories.
+        $categories = $this->get_random_categories();
+
+        // Convert the randomly chosen categories to a comma-separated string of IDs.
         $strcategories = implode(',', array_column($categories, 'id'));
 
         // Set the configuration settings for the coursepilot enrolment plugin, disabled first.
@@ -196,7 +198,7 @@ class external_test extends advanced_testcase {
         $this->set_enrol_coursepilot_settings($data);
 
         // Retrieve the template categories.
-        $formationcategories = external::get_formations_categories();
+        $formationcategories = \enrol_coursepilot\external::get_formations_categories();
 
         // Assert that the template categories retrieved are empty.
         $this->assertEmpty($formationcategories);
@@ -206,7 +208,7 @@ class external_test extends advanced_testcase {
         $this->set_enrol_coursepilot_settings($data);
 
         // Retrieve the template categories.
-        $formationcategories = external::get_formations_categories();
+        $formationcategories = \enrol_coursepilot\external::get_formations_categories();
 
         // Assert that the template categories are retrieved successfully.
         $this->assertCount($this->randomcategories, $formationcategories);

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -100,7 +100,7 @@ class external_test extends advanced_testcase {
     }
 
     /**
-     * Test method for retrieving settings of course categories via the external API.
+     * Test method get_template_categories via the external API.
      *
      * This method is designed to test the functionality of getting
      * settings for course categories within the Moodle environment.
@@ -137,6 +137,48 @@ class external_test extends advanced_testcase {
 
         // Assert that the template categories are correct.
         foreach ($templatecategories as $category) {
+            $this->assertContains($category['id'], array_column($categories, 'id'));
+        }
+    }
+
+    /**
+     * Test method get_formations_categories via the external API.
+     *
+     * This method is designed to test the functionality of getting
+     * settings for course categories within the Moodle environment.
+     *
+     * @return void
+     */
+    public function test_get_formations_categories() {
+        // We choose random categories to set as template categories.
+        $categories = array_slice($this->categories, 0, $this->randomcategories);
+        $strcategories = implode(',', array_column($categories, 'id'));
+
+        // Set the configuration settings for the coursepilot enrolment plugin, disabled first.
+        $data = [
+            'enable' => 0,
+            'formationcategories' => $strcategories
+        ];
+        $this->set_enrol_coursepilot_settings($data);
+
+        // Retrieve the template categories.
+        $formationcategories = external::get_formations_categories();
+
+        // Assert that the template categories retrieved are empty.
+        $this->assertEmpty($formationcategories);
+
+        // Now we set the configuration settings for the coursepilot enrolment plugin, enabled.
+        $data['enable'] = 1;
+        $this->set_enrol_coursepilot_settings($data);
+
+        // Retrieve the template categories.
+        $formationcategories = external::get_formations_categories();
+
+        // Assert that the template categories are retrieved successfully.
+        $this->assertCount($this->randomcategories, $formationcategories);
+
+        // Assert that the template categories are correct.
+        foreach ($formationcategories as $category) {
             $this->assertContains($category['id'], array_column($categories, 'id'));
         }
     }

--- a/test/external_test.php
+++ b/test/external_test.php
@@ -132,7 +132,7 @@ class external_test extends advanced_testcase {
     }
 
     /**
-     * Test method get_formations_categories via the external API.
+     * Test method get_template_categories via the external API.
      *
      * This method is designed to test the functionality of getting
      * settings for course categories within the Moodle environment.

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_coursepilot';
 $plugin->release   = '1.0.0';
-$plugin->version   = 2024102600;
+$plugin->version   = 2024102700;
 $plugin->requires  = 2024042204;  // Requires Moodle 4.4.4.
 $plugin->supported = [404, 405];  // Supports Moodle 4.4 and 4.5.
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_coursepilot';
 $plugin->release   = '1.0.0';
-$plugin->version   = 2024102400;
+$plugin->version   = 2024102500;
 $plugin->requires  = 2024042204;  // Requires Moodle 4.4.4.
 $plugin->supported = [404, 405];  // Supports Moodle 4.4 and 4.5.
 $plugin->maturity  = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'enrol_coursepilot';
 $plugin->release   = '1.0.0';
-$plugin->version   = 2024101500;
+$plugin->version   = 2024101600;
 $plugin->requires  = 2024042204;  // Requires Moodle 4.4.4.
 $plugin->supported = [404, 405];  // Supports Moodle 4.4 and 4.5.
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
DEV-ISSUE-03: enrol_coursepilot Get formations categories

**Story**
As a web service consumer I can get the formations category id using a web service function

https://github.com/sofhouse/moodle-enrol_coursepilot/issues/3